### PR TITLE
[Feat/#2] 기본 도메인 엔티티 정의 및 서비스 레이어 패키지 구성

### DIFF
--- a/src/main/java/backend/receipt/love/controller/LoveController.java
+++ b/src/main/java/backend/receipt/love/controller/LoveController.java
@@ -1,0 +1,4 @@
+package backend.receipt.love.controller;
+
+public class LoveController {
+}

--- a/src/main/java/backend/receipt/love/domain/Love.java
+++ b/src/main/java/backend/receipt/love/domain/Love.java
@@ -1,0 +1,17 @@
+package backend.receipt.love.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Love {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "love_id")
+    private Long id;
+}

--- a/src/main/java/backend/receipt/love/repository/LoveRepository.java
+++ b/src/main/java/backend/receipt/love/repository/LoveRepository.java
@@ -1,0 +1,4 @@
+package backend.receipt.love.repository;
+
+public class LoveRepository {
+}

--- a/src/main/java/backend/receipt/love/service/LoveService.java
+++ b/src/main/java/backend/receipt/love/service/LoveService.java
@@ -1,0 +1,4 @@
+package backend.receipt.love.service;
+
+public class LoveService {
+}

--- a/src/main/java/backend/receipt/member/controller/MemberController.java
+++ b/src/main/java/backend/receipt/member/controller/MemberController.java
@@ -1,0 +1,2 @@
+package backend.receipt.member.controller;public class MemberController {
+}

--- a/src/main/java/backend/receipt/member/controller/MemberController.java
+++ b/src/main/java/backend/receipt/member/controller/MemberController.java
@@ -1,2 +1,4 @@
-package backend.receipt.member.controller;public class MemberController {
+package backend.receipt.member.controller;
+
+public class MemberController {
 }

--- a/src/main/java/backend/receipt/member/domain/Member.java
+++ b/src/main/java/backend/receipt/member/domain/Member.java
@@ -1,2 +1,19 @@
-package backend.receipt.member.domain;public class Member {
+package backend.receipt.member.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
 }

--- a/src/main/java/backend/receipt/member/domain/Member.java
+++ b/src/main/java/backend/receipt/member/domain/Member.java
@@ -1,0 +1,2 @@
+package backend.receipt.member.domain;public class Member {
+}

--- a/src/main/java/backend/receipt/member/repository/MemberRepository.java
+++ b/src/main/java/backend/receipt/member/repository/MemberRepository.java
@@ -1,2 +1,4 @@
-package backend.receipt.member.repository;public class MemberRepository {
+package backend.receipt.member.repository;
+
+public class MemberRepository {
 }

--- a/src/main/java/backend/receipt/member/repository/MemberRepository.java
+++ b/src/main/java/backend/receipt/member/repository/MemberRepository.java
@@ -1,0 +1,2 @@
+package backend.receipt.member.repository;public class MemberRepository {
+}

--- a/src/main/java/backend/receipt/member/service/MemberService.java
+++ b/src/main/java/backend/receipt/member/service/MemberService.java
@@ -1,0 +1,2 @@
+package backend.receipt.member.service;public class MemberService {
+}

--- a/src/main/java/backend/receipt/member/service/MemberService.java
+++ b/src/main/java/backend/receipt/member/service/MemberService.java
@@ -1,2 +1,4 @@
-package backend.receipt.member.service;public class MemberService {
+package backend.receipt.member.service;
+
+public class MemberService {
 }

--- a/src/main/java/backend/receipt/point/controller/PointController.java
+++ b/src/main/java/backend/receipt/point/controller/PointController.java
@@ -1,0 +1,2 @@
+package backend.receipt.point.controller;public class PointController {
+}

--- a/src/main/java/backend/receipt/point/controller/PointController.java
+++ b/src/main/java/backend/receipt/point/controller/PointController.java
@@ -1,2 +1,4 @@
-package backend.receipt.point.controller;public class PointController {
+package backend.receipt.point.controller;
+
+public class PointController {
 }

--- a/src/main/java/backend/receipt/point/domain/Point.java
+++ b/src/main/java/backend/receipt/point/domain/Point.java
@@ -1,2 +1,18 @@
-package backend.receipt.point.domain;public class Point {
+package backend.receipt.point.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Point {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="point_id")
+    private Long id;
+
 }

--- a/src/main/java/backend/receipt/point/domain/Point.java
+++ b/src/main/java/backend/receipt/point/domain/Point.java
@@ -1,0 +1,2 @@
+package backend.receipt.point.domain;public class Point {
+}

--- a/src/main/java/backend/receipt/point/repository/PointRepository.java
+++ b/src/main/java/backend/receipt/point/repository/PointRepository.java
@@ -1,2 +1,4 @@
-package backend.receipt.point.repository;public class PointRepository {
+package backend.receipt.point.repository;
+
+public class PointRepository {
 }

--- a/src/main/java/backend/receipt/point/repository/PointRepository.java
+++ b/src/main/java/backend/receipt/point/repository/PointRepository.java
@@ -1,0 +1,2 @@
+package backend.receipt.point.repository;public class PointRepository {
+}

--- a/src/main/java/backend/receipt/point/service/PointService.java
+++ b/src/main/java/backend/receipt/point/service/PointService.java
@@ -1,2 +1,4 @@
-package backend.receipt.point.service;public class PointService {
+package backend.receipt.point.service;
+
+public class PointService {
 }

--- a/src/main/java/backend/receipt/point/service/PointService.java
+++ b/src/main/java/backend/receipt/point/service/PointService.java
@@ -1,0 +1,2 @@
+package backend.receipt.point.service;public class PointService {
+}

--- a/src/main/java/backend/receipt/purchase/controller/PurchaseController.java
+++ b/src/main/java/backend/receipt/purchase/controller/PurchaseController.java
@@ -1,2 +1,4 @@
-package backend.receipt.purchase.controller;public class PointController {
+package backend.receipt.purchase.controller;
+
+public class PurchaseController {
 }

--- a/src/main/java/backend/receipt/purchase/controller/PurchaseController.java
+++ b/src/main/java/backend/receipt/purchase/controller/PurchaseController.java
@@ -1,0 +1,2 @@
+package backend.receipt.purchase.controller;public class PointController {
+}

--- a/src/main/java/backend/receipt/purchase/domain/Purchase.java
+++ b/src/main/java/backend/receipt/purchase/domain/Purchase.java
@@ -1,2 +1,18 @@
-package backend.receipt.purchase.domain;public class Purchaser {
+package backend.receipt.purchase.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Purchase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="purchase_id")
+    private Long id;
 }

--- a/src/main/java/backend/receipt/purchase/domain/Purchase.java
+++ b/src/main/java/backend/receipt/purchase/domain/Purchase.java
@@ -1,0 +1,2 @@
+package backend.receipt.purchase.domain;public class Purchaser {
+}

--- a/src/main/java/backend/receipt/purchase/repository/PurchaseRepository.java
+++ b/src/main/java/backend/receipt/purchase/repository/PurchaseRepository.java
@@ -1,2 +1,4 @@
-package backend.receipt.purchase.repository;public class PurchaseRepository {
+package backend.receipt.purchase.repository;
+
+public class PurchaseRepository {
 }

--- a/src/main/java/backend/receipt/purchase/repository/PurchaseRepository.java
+++ b/src/main/java/backend/receipt/purchase/repository/PurchaseRepository.java
@@ -1,0 +1,2 @@
+package backend.receipt.purchase.repository;public class PurchaseRepository {
+}

--- a/src/main/java/backend/receipt/purchase/service/PurchaseService.java
+++ b/src/main/java/backend/receipt/purchase/service/PurchaseService.java
@@ -1,0 +1,2 @@
+package backend.receipt.purchase.service;public class PurchaseService {
+}

--- a/src/main/java/backend/receipt/purchase/service/PurchaseService.java
+++ b/src/main/java/backend/receipt/purchase/service/PurchaseService.java
@@ -1,2 +1,4 @@
-package backend.receipt.purchase.service;public class PurchaseService {
+package backend.receipt.purchase.service;
+
+public class PurchaseService {
 }

--- a/src/main/java/backend/receipt/review/controller/ReviewController.java
+++ b/src/main/java/backend/receipt/review/controller/ReviewController.java
@@ -1,0 +1,2 @@
+package backend.receipt.review.controller;public class ReviewController {
+}

--- a/src/main/java/backend/receipt/review/controller/ReviewController.java
+++ b/src/main/java/backend/receipt/review/controller/ReviewController.java
@@ -1,2 +1,4 @@
-package backend.receipt.review.controller;public class ReviewController {
+package backend.receipt.review.controller;
+
+public class ReviewController {
 }

--- a/src/main/java/backend/receipt/review/domain/Review.java
+++ b/src/main/java/backend/receipt/review/domain/Review.java
@@ -1,2 +1,18 @@
-package backend.receipt.review.domain;public class Review {
+package backend.receipt.review.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Review {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_id")
+    private Long id;
 }

--- a/src/main/java/backend/receipt/review/domain/Review.java
+++ b/src/main/java/backend/receipt/review/domain/Review.java
@@ -1,0 +1,2 @@
+package backend.receipt.review.domain;public class Review {
+}

--- a/src/main/java/backend/receipt/review/repository/ReviewRepository.java
+++ b/src/main/java/backend/receipt/review/repository/ReviewRepository.java
@@ -1,2 +1,4 @@
-package backend.receipt.review.repository;public class ReviewRepository {
+package backend.receipt.review.repository;
+
+public class ReviewRepository {
 }

--- a/src/main/java/backend/receipt/review/repository/ReviewRepository.java
+++ b/src/main/java/backend/receipt/review/repository/ReviewRepository.java
@@ -1,0 +1,2 @@
+package backend.receipt.review.repository;public class ReviewRepository {
+}

--- a/src/main/java/backend/receipt/review/service/ReviewService.java
+++ b/src/main/java/backend/receipt/review/service/ReviewService.java
@@ -1,2 +1,4 @@
-package backend.receipt.review.service;public class ReviewService {
+package backend.receipt.review.service;
+
+public class ReviewService {
 }

--- a/src/main/java/backend/receipt/review/service/ReviewService.java
+++ b/src/main/java/backend/receipt/review/service/ReviewService.java
@@ -1,0 +1,2 @@
+package backend.receipt.review.service;public class ReviewService {
+}

--- a/src/main/java/backend/receipt/store/controller/StoreController.java
+++ b/src/main/java/backend/receipt/store/controller/StoreController.java
@@ -1,0 +1,2 @@
+package backend.receipt.store.controller;public class ReviewController {
+}

--- a/src/main/java/backend/receipt/store/controller/StoreController.java
+++ b/src/main/java/backend/receipt/store/controller/StoreController.java
@@ -1,2 +1,4 @@
-package backend.receipt.store.controller;public class ReviewController {
+package backend.receipt.store.controller;
+
+public class StoreController {
 }

--- a/src/main/java/backend/receipt/store/domain/Store.java
+++ b/src/main/java/backend/receipt/store/domain/Store.java
@@ -1,0 +1,2 @@
+package backend.receipt.store.domain;public class Store {
+}

--- a/src/main/java/backend/receipt/store/domain/Store.java
+++ b/src/main/java/backend/receipt/store/domain/Store.java
@@ -1,2 +1,17 @@
-package backend.receipt.store.domain;public class Store {
+package backend.receipt.store.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Store {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "store_id")
+    private Long id;
 }

--- a/src/main/java/backend/receipt/store/repository/StoreRepository.java
+++ b/src/main/java/backend/receipt/store/repository/StoreRepository.java
@@ -1,2 +1,4 @@
-package backend.receipt.store.repository;public class StoreRepository {
+package backend.receipt.store.repository;
+
+public class StoreRepository {
 }

--- a/src/main/java/backend/receipt/store/repository/StoreRepository.java
+++ b/src/main/java/backend/receipt/store/repository/StoreRepository.java
@@ -1,0 +1,2 @@
+package backend.receipt.store.repository;public class StoreRepository {
+}

--- a/src/main/java/backend/receipt/store/service/StoreService.java
+++ b/src/main/java/backend/receipt/store/service/StoreService.java
@@ -1,0 +1,2 @@
+package backend.receipt.store.service;public class StoreService {
+}

--- a/src/main/java/backend/receipt/store/service/StoreService.java
+++ b/src/main/java/backend/receipt/store/service/StoreService.java
@@ -1,2 +1,4 @@
-package backend.receipt.store.service;public class StoreService {
+package backend.receipt.store.service;
+
+public class StoreService {
 }


### PR DESCRIPTION
## 📝 요약(Summary)
- 기본 도메인 엔티티 정의 및 서비스 레이어 패키지 구성

## 🛠️ PR 유형
- Member/Store/Purchase/Love/Review/Point 도메인 엔티티 정의
- 서비스 레이어 패키지 구성

## 💬 공유사항
- 영수증 관련 도메인은 프로젝트 이름과 겹쳐서 purchase로 이름 변경

(이슈에 대한 작업완료시) close #2 
