### PR TITLE
[fix/#12]: Spring Security 기본 인증 해제 및 전역 permitAll 적용

### DIFF
--- a/src/main/java/backend/receipt/gobal/config/SecurityConfig.java
+++ b/src/main/java/backend/receipt/gobal/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package backend.receipt.member.config;
+package backend.receipt.gobal.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,11 +13,8 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
-                .headers(headers -> headers.frameOptions(frame -> frame.disable()))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(new AntPathRequestMatcher("/api/v1/auth/sign-up")).permitAll()
-                        .requestMatchers(new AntPathRequestMatcher("/api/v1/stores/**")).permitAll()
-                        .anyRequest().authenticated()
+                        .anyRequest().permitAll()
                 );
 
         return http.build();


### PR DESCRIPTION
## 📝 요약(Summary)
- Spring Security 설정에서 .anyRequest().authenticated()로 모든 요청에 인증을 요구함
- JWT 기반 인증 로직이 아직 구현되지 않음
- 인증 필터가 없는 상태에서 인증이 필요한 요청이 들어와 → Spring Security가 접근 차단 (403) 문제 발생 -> 해결

## 🛠️ PR 유형
- [ ] security 관련 오류 해결
SecurityConfig 설정을 임시로 수정하여 모든 요청에 대해 permitAll() 적용
JWT 인증이 완성되기 전까지는 인증 요구를 잠시 비활성화하여 테스트 및 개발 가능하도록 조치

## 💬 공유사항
- api 구현할 때 global/config 파일에 api 추가 할 필요 없음
